### PR TITLE
Working info bar for the landing page info section

### DIFF
--- a/app/client/style.css
+++ b/app/client/style.css
@@ -15,4 +15,8 @@
   left:30%
 }
 
-
+.background-bar {
+  background-size: cover;
+  background: #17252a no-repeat center center fixed;
+  height: 450px;
+}

--- a/app/imports/ui/components/FullWidthImage.jsx
+++ b/app/imports/ui/components/FullWidthImage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Header, Container, Grid, Icon, Image } from 'semantic-ui-react';
+import LandingBar from './LandingBar';
 
 export default class FullWidthImage extends React.Component {
   render() {
@@ -24,17 +25,12 @@ export default class FullWidthImage extends React.Component {
       borderRadius: '20px',
       paddingBottom: '16px',
       paddingTop: '16px',
+      marginBottom: '360px',
     };
     const headerStyle = {
       fontFamily: 'Baven',
       opacity: '10 !important',
       color: '#17252a',
-    };
-    const headerStyle2 = {
-      marginTop: '600px',
-      fontFamily: 'Baven',
-      paddingBottom: '16px',
-      paddingTop: '16px',
     };
     const imageStyle = { opacity: '0.9' };
     return (
@@ -55,20 +51,9 @@ export default class FullWidthImage extends React.Component {
                 </Header>
               </Container>
 
-              <Container fluid style={infoContainerStyle}>
-                <Header style={headerStyle2} as='h2' icon textAlign='center'>
-                  <Icon name='users' circular/>
-                  <Header.Content>A community for the community</Header.Content>
-                </Header>
-                <Header style={headerStyle} textAlign='center' as='h3'>
-                  At UH Bazaar, the focus is the student.  What UHB aims to provide is
-                  a comfortable and easy experience when it comes to getting the things
-                  you need.  Leaving more time and energy to focus on what matters: Learning.
-                </Header>
-              </Container>
-
             </Container>
           </Grid>
+          <LandingBar/>
         </Container>
     );
   }

--- a/app/imports/ui/components/LandingBar.jsx
+++ b/app/imports/ui/components/LandingBar.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Grid, Header, Icon } from 'semantic-ui-react';
+
+export default class LandingBar extends React.Component {
+  render() {
+    const headerStyle2 = {
+      fontFamily: 'Baven',
+      fontSize: '20px',
+      color: '#feffff',
+    };
+
+    return (
+        <div className='background-bar'>
+          <Grid container textAlign='center' verticalAlign='middle'>
+            <Grid.Row>
+            </Grid.Row>
+            <Grid.Row>
+            </Grid.Row>
+            <Grid.Row>
+              <Header style={headerStyle2} as='h2' icon textAlign='center'>
+                <Icon name='users' circular color='grey' inverted/>
+                <Header.Content style={headerStyle2}>A community for the community</Header.Content>
+              </Header>
+            </Grid.Row>
+            <Grid.Row>
+              <p style={headerStyle2}>At UH Bazaar, the focus is the student.  What UHB aims to provide is
+                a comfortable and easy experience when it comes to getting the things
+                you need.  Leaving more time and energy to focus on what matters: Learning.
+              </p>
+            </Grid.Row>
+          </Grid>
+        </div>
+    );
+  }
+}


### PR DESCRIPTION
Turned the info container into a colored bar spanning the width of the page.
This still needs adjustments to have uniform padding and color adjustments, etc... I wanted to get this into upstream so that everybody could have this landing page.  I created a landing bar component that is used in the full width image component, the full width component is then used in the actual landing page.

<img width="800" alt="screen shot 2018-11-12 at 2 31 59 pm" src="https://user-images.githubusercontent.com/39782863/48382946-bebf9480-e687-11e8-8949-d1cbd82554c3.png">
