### PR TITLE
Update showcase + Create user profile for collection

### DIFF
--- a/app/imports/ui/components/CategoryMenu.jsx
+++ b/app/imports/ui/components/CategoryMenu.jsx
@@ -7,23 +7,23 @@ class CategoryMenu extends React.Component {
 
   render() {
     return (
-                <Card raised link>
-                  <Image src={this.props.item.image}/>
-                  <Card.Content>
-                    <Card.Header>{this.props.item.name}</Card.Header>
-                    <Card.Description>{this.props.item.description}</Card.Description>
-                  </Card.Content>
-                  <Card.Content extra>
-                    <Icon name='money'/>
-                    <span className='price'>{`$${this.props.item.price}`}</span>
-                  </Card.Content>
-                  <Card.Content extra>
-                    <span className='location'>{this.props.item.location}</span>
-                  </Card.Content>
-                  <Card.Content extra>
-                    <span className='seller'>{this.props.item.owner}</span>
-                  </Card.Content>
-                </Card>
+        <Card raised link>
+          <Image src={this.props.item.image}/>
+          <Card.Content>
+            <Card.Header>{this.props.item.name}</Card.Header>
+            <Card.Description>{this.props.item.description}</Card.Description>
+          </Card.Content>
+          <Card.Content extra>
+            <Icon name='money'/>
+            <span className='price'>{`$${this.props.item.price}`}</span>
+          </Card.Content>
+          <Card.Content extra>
+            <span className='location'>{this.props.item.location}</span>
+          </Card.Content>
+          <Card.Content extra>
+            <span className='seller'>{this.props.item.owner}</span>
+          </Card.Content>
+        </Card>
     );
   }
 }

--- a/app/imports/ui/components/CategoryMenu.jsx
+++ b/app/imports/ui/components/CategoryMenu.jsx
@@ -8,7 +8,7 @@ class CategoryMenu extends React.Component {
   render() {
     return (
                 <Card raised link>
-                  <Image src={`images/${this.props.item.image}`}/>
+                  <Image src={this.props.item.image}/>
                   <Card.Content>
                     <Card.Header>{this.props.item.name}</Card.Header>
                     <Card.Description>{this.props.item.description}</Card.Description>

--- a/app/imports/ui/components/FullWidthImage.jsx
+++ b/app/imports/ui/components/FullWidthImage.jsx
@@ -3,7 +3,6 @@ import { Header, Container, Grid, Button } from 'semantic-ui-react';
 import { Link } from 'react-router-dom';
 import LandingBar from './LandingBar';
 
-
 export default class FullWidthImage extends React.Component {
   render() {
     const mainContainerStyle = {
@@ -29,13 +28,6 @@ export default class FullWidthImage extends React.Component {
       paddingRight: '16px',
       fontSize: '80px',
     };
-
-    const headerTwoStyle = {
-      fontFamily: 'PT Sans Caption',
-      marginLeft: '150px',
-      fontSize: '80px',
-      color: '#084543',
-    };
     const buttonOneStyle = {
       fontFamily: 'PT Sans Caption',
       // color: '#084543',
@@ -44,7 +36,6 @@ export default class FullWidthImage extends React.Component {
       fontSize: '20px',
 
     };
-
     const buttonTwoStyle = {
       fontFamily: 'PT Sans Caption',
       fontSize: '20px',
@@ -60,18 +51,18 @@ export default class FullWidthImage extends React.Component {
                 CLASSIFIED ADS AND COMMUNITY NOTICES FOR THE UHM OHANA
               </Header>
 
-            <Grid centered>
-              <Link to={'/signup'}>
-              <Button basic color={'black'} style={buttonOneStyle}>
-                BECOME A MEMBER
-              </Button>
-              </Link>
-               <Link to={'/signin'}>
-              <Button color={'black'} style={buttonTwoStyle} >
-                LOGIN
-              </Button>
-               </Link>
-            </Grid>
+              <Grid centered>
+                <Link to={'/signup'}>
+                  <Button basic color={'black'} style={buttonOneStyle}>
+                    BECOME A MEMBER
+                  </Button>
+                </Link>
+                <Link to={'/signin'}>
+                  <Button color={'black'} style={buttonTwoStyle}>
+                    LOGIN
+                  </Button>
+                </Link>
+              </Grid>
             </Container>
           </Grid>
           <LandingBar/>

--- a/app/imports/ui/components/NavBar.jsx
+++ b/app/imports/ui/components/NavBar.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Meteor } from 'meteor/meteor';
 import { withTracker } from 'meteor/react-meteor-data';
 import { withRouter, NavLink } from 'react-router-dom';
-import { Menu, Dropdown, Image, Icon } from 'semantic-ui-react';
+import { Menu, Dropdown, Image } from 'semantic-ui-react';
 import { Roles } from 'meteor/alanning:roles';
 import SearchBar from './SearchBar';
 

--- a/app/imports/ui/components/SearchBar.jsx
+++ b/app/imports/ui/components/SearchBar.jsx
@@ -56,7 +56,7 @@ class SearchBar extends Component {
 /** Require an array of Stuff documents in the props. */
 SearchBar.propTypes = {
   items: PropTypes.array.isRequired,
-  ready: PropTypes.bool.isRequired,
+  ready: PropTypes.string.isRequired,
 };
 
 /** withTracker connects Meteor data to React components. https://guide.meteor.com/react.html#using-withTracker */
@@ -65,6 +65,6 @@ export default withTracker(() => {
   const subscription = Meteor.subscribe('Items');
   return {
     items: Items.find({}).fetch(),
-    ready: subscription.ready(),
+    ready: (subscription.ready()).toString(),
   };
 })(SearchBar);

--- a/app/imports/ui/components/ShowcaseItem.jsx
+++ b/app/imports/ui/components/ShowcaseItem.jsx
@@ -3,22 +3,31 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link, withRouter } from 'react-router-dom';
 
-class ShowcaseItem extends React.Component{
+class ShowcaseItem extends React.Component {
   render() {
-    const cardFontStyle = { color: '#17252a' };
-    const buttonStyle = { marginTop: '16px' };
+    const cardFontStyle = {
+      color: '#17252a',
+      marginBottom: '8px',
+      fontWeight: 'bold',
+      fontSize: '16px',
+    };
+    const imageStyle = { marginLeft: '32px' };
     return (
         <Item.Group>
-        <Item>
-          <Item.Image src={this.props.item.image}/>
-          <Item.Content>
-            <Item.Description style={cardFontStyle}>
-              {this.props.item.title}
-            </Item.Description>
-            <Button style={buttonStyle} floated='right'>View</Button>
-          </Item.Content>
-        </Item>
-        <hr/>
+          <Item>
+            <Item.Image rounded size='medium' style={imageStyle} src={this.props.item.image}/>
+            <Item.Content verticalAlign='middle'>
+              <Item.Description style={cardFontStyle}>
+                {this.props.item.title}
+              </Item.Description>
+              <Button.Group size='large'>
+                <Button color='blue'>View</Button>
+                <Button.Or/>
+                <Button color='green'>Barter</Button>
+              </Button.Group>
+            </Item.Content>
+          </Item>
+          <hr/>
         </Item.Group>
     );
   }

--- a/app/imports/ui/components/ShowcaseItem.jsx
+++ b/app/imports/ui/components/ShowcaseItem.jsx
@@ -1,0 +1,33 @@
+import { Button, Item } from 'semantic-ui-react';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link, withRouter } from 'react-router-dom';
+
+class ShowcaseItem extends React.Component{
+  render() {
+    const cardFontStyle = { color: '#17252a' };
+    const buttonStyle = { marginTop: '16px' };
+    return (
+        <Item.Group>
+        <Item>
+          <Item.Image src={this.props.item.image}/>
+          <Item.Content>
+            <Item.Description style={cardFontStyle}>
+              {this.props.item.title}
+            </Item.Description>
+            <Button style={buttonStyle} floated='right'>View</Button>
+          </Item.Content>
+        </Item>
+        <hr/>
+        </Item.Group>
+    );
+  }
+}
+
+/** Require a document to be passed to this component. */
+ShowcaseItem.propTypes = {
+  item: PropTypes.object.isRequired,
+};
+
+/** Wrap this component in withRouter since we use the <Link> React Router element. */
+export default withRouter(ShowcaseItem);

--- a/app/imports/ui/components/ShowcaseItem.jsx
+++ b/app/imports/ui/components/ShowcaseItem.jsx
@@ -1,7 +1,7 @@
 import { Button, Item } from 'semantic-ui-react';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link, withRouter } from 'react-router-dom';
+import { withRouter } from 'react-router-dom';
 
 class ShowcaseItem extends React.Component {
   render() {

--- a/app/imports/ui/components/UserProfileShowcase.jsx
+++ b/app/imports/ui/components/UserProfileShowcase.jsx
@@ -16,9 +16,9 @@ class UserShowCase extends React.Component {
     return (
         <Grid container centered style={showcaseStyle}>
 
-          <Card style={cardColor}>
+          <Card fluid style={cardColor}>
             <Card.Content>
-              <Card.Header style={cardFontStyle}><Icon name='warehouse' circular/>My Stuff</Card.Header>
+              <Card.Header style={cardFontStyle}><Icon name='warehouse' circular/>The Goods</Card.Header>
             </Card.Content>
             <Card.Content>
               <Item.Group>

--- a/app/imports/ui/components/UserProfileShowcase.jsx
+++ b/app/imports/ui/components/UserProfileShowcase.jsx
@@ -1,18 +1,16 @@
 import React from 'react';
-import { Grid, Card, Button, Icon, Item } from 'semantic-ui-react';
+import { Grid, Card, Icon, Item } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 import { withTracker } from 'meteor/react-meteor-data';
 import { Meteor } from 'meteor/meteor';
 import ShowcaseItem from './ShowcaseItem';
 import { Items } from '../../api/item/item';
-import { Users } from '/imports/api/user/user';
 
 class UserShowCase extends React.Component {
   render() {
     const showcaseStyle = { marginTop: '8px', marginBottom: '128px' };
     const cardColor = { backgroundColor: '#feffff' };
     const cardFontStyle = { color: '#17252a' };
-    const buttonStyle = { marginTop: '16px' };
     return (
         <Grid container centered style={showcaseStyle}>
 

--- a/app/imports/ui/components/UserProfileShowcase.jsx
+++ b/app/imports/ui/components/UserProfileShowcase.jsx
@@ -5,6 +5,7 @@ import { withTracker } from 'meteor/react-meteor-data';
 import { Meteor } from 'meteor/meteor';
 import ShowcaseItem from './ShowcaseItem';
 import { Items } from '../../api/item/item';
+import { Users } from '/imports/api/user/user';
 
 class UserShowCase extends React.Component {
   render() {

--- a/app/imports/ui/components/UserProfileShowcase.jsx
+++ b/app/imports/ui/components/UserProfileShowcase.jsx
@@ -1,53 +1,29 @@
 import React from 'react';
-import { Grid, Card, Button, Icon, Feed } from 'semantic-ui-react';
+import { Grid, Card, Button, Icon, Item } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import { withTracker } from 'meteor/react-meteor-data';
+import { Meteor } from 'meteor/meteor';
+import ShowcaseItem from './ShowcaseItem';
+import { Items } from '../../api/item/item';
 
-export default class UserShowCase extends React.Component {
+class UserShowCase extends React.Component {
   render() {
     const showcaseStyle = { marginTop: '8px', marginBottom: '128px' };
     const cardColor = { backgroundColor: '#feffff' };
     const cardFontStyle = { color: '#17252a' };
+    const buttonStyle = { marginTop: '16px' };
     return (
         <Grid container centered style={showcaseStyle}>
 
           <Card style={cardColor}>
             <Card.Content>
-              <Card.Header style={cardFontStyle}><Icon name='trophy' circular/>Showcase</Card.Header>
+              <Card.Header style={cardFontStyle}><Icon name='warehouse' circular/>My Stuff</Card.Header>
             </Card.Content>
             <Card.Content>
-              <Feed>
-                <Feed.Event>
-                  <Feed.Label image='/images/backpack.jpg'/>
-                  <Feed.Content>
-                    <Feed.Date content='1 day ago'/>
-                    <Feed.Summary style={cardFontStyle}>
-                      Backpack
-                      <Button floated='right'>View</Button>
-                    </Feed.Summary>
-                  </Feed.Content>
-                </Feed.Event>
-
-                <Feed.Event>
-                  <Feed.Label image='/images/scooter.jpeg'/>
-                  <Feed.Content>
-                    <Feed.Date content='3 days ago'/>
-                    <Feed.Summary style={cardFontStyle}>
-                      Razor Scooter
-                      <Button floated='right'>View</Button>
-                    </Feed.Summary>
-                  </Feed.Content>
-                </Feed.Event>
-
-                <Feed.Event>
-                  <Feed.Label image='/images/textbook.jpeg'/>
-                  <Feed.Content>
-                    <Feed.Date content='4 days ago'/>
-                    <Feed.Summary style={cardFontStyle}>
-                      CLRS Textbook
-                      <Button floated='right'>View</Button>
-                    </Feed.Summary>
-                  </Feed.Content>
-                </Feed.Event>
-              </Feed>
+              <Item.Group>
+                {this.props.item.map((item, index) => <ShowcaseItem key={index}
+                                                                 item={item}/>)}
+              </Item.Group>
             </Card.Content>
           </Card>
 
@@ -55,3 +31,18 @@ export default class UserShowCase extends React.Component {
     );
   }
 }
+
+UserShowCase.propTypes = {
+  item: PropTypes.array.isRequired,
+  ready: PropTypes.bool.isRequired,
+};
+
+/** withTracker connects Meteor data to React components. https://guide.meteor.com/react.html#using-withTracker */
+export default withTracker(() => {
+  // Get access to Stuff documents.
+  const subscription = Meteor.subscribe('Items');
+  return {
+    item: Items.find({}).fetch(),
+    ready: (subscription.ready()),
+  };
+})(UserShowCase);

--- a/app/imports/ui/layouts/App.jsx
+++ b/app/imports/ui/layouts/App.jsx
@@ -22,6 +22,7 @@ import UserProfile from '../pages/UserProfile';
 import EditUserProfile from '../pages/EditUserProfile';
 import ShowUsers from '../pages/ShowUsers';
 import UserProfileById from '../pages/UserProfileById';
+import CreateUserProfile from '../pages/CreateUserProfile';
 
 /** Top-level layout component for this application. Called in imports/startup/client/startup.jsx. */
 class App extends React.Component {
@@ -37,6 +38,7 @@ class App extends React.Component {
               <Route path="/signup" component={Signup}/>
               <Route exact path="/categoriespage" component={CategoriesPage}/>
               <Route path="/showusers" component={ShowUsers}/>
+              <Route path="/createuserprofile" component={CreateUserProfile}/>
               <ProtectedRoute path="/list" component={ListItem}/>
               <Route path="/categorypage/:name/:icon" component={CategoryPage}/>
               <ProtectedRoute path="/add" component={AddStuff}/>

--- a/app/imports/ui/layouts/App.jsx
+++ b/app/imports/ui/layouts/App.jsx
@@ -38,7 +38,7 @@ class App extends React.Component {
               <Route exact path="/categoriespage" component={CategoriesPage}/>
               <Route path="/showusers" component={ShowUsers}/>
               <ProtectedRoute path="/list" component={ListItem}/>
-              <Route path="/categorypage/:name" component={CategoryPage}/>
+              <Route path="/categorypage/:name/:icon" component={CategoryPage}/>
               <ProtectedRoute path="/add" component={AddStuff}/>
               <ProtectedRoute path="/createitem" component={CreateItem}/>
               <ProtectedRoute path="/edit/:_id" component={EditStuff}/>

--- a/app/imports/ui/pages/CategoryPage.jsx
+++ b/app/imports/ui/pages/CategoryPage.jsx
@@ -29,7 +29,7 @@ class CategoryPage extends React.Component {
     const mainContainerStyle = {
       paddingTop: '20px',
       paddingBottom: '20px',
-      marginBottom: '24vh',
+      marginBottom: '60vh',
     };
     const catSideMenu = {
       fontWeight: 'bold',
@@ -43,6 +43,7 @@ class CategoryPage extends React.Component {
                 as={Menu}
                 vertical
                 visible={visible}
+                style={mainContainerStyle}
                 width='wide'>
               <Menu.Item>
                 <Menu.Header style={titleStyle}>

--- a/app/imports/ui/pages/CreateItem.jsx
+++ b/app/imports/ui/pages/CreateItem.jsx
@@ -36,7 +36,7 @@ class CreateItem extends React.Component {
   submit(data) {
     const { title, price, location, image, category, description } = data;
     const owner = Meteor.user().username;
-    const date = '11/09/1998'
+    const date = '11/09/1998';
     Items.insert({ title, price, location, image, category, description, owner, date }, this.insertCallback);
   }
 

--- a/app/imports/ui/pages/CreateUserProfile.jsx
+++ b/app/imports/ui/pages/CreateUserProfile.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid, Loader, Header, Segment, Button, Container } from 'semantic-ui-react';
+import { Grid, Header, Segment, Container } from 'semantic-ui-react';
 import { Users, UserSchema } from '/imports/api/user/user';
 import { Bert } from 'meteor/themeteorchef:bert';
 import { Meteor } from 'meteor/meteor';

--- a/app/imports/ui/pages/CreateUserProfile.jsx
+++ b/app/imports/ui/pages/CreateUserProfile.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Grid, Loader, Header, Segment, Button, Container } from 'semantic-ui-react';
+import { Users, UserSchema } from '/imports/api/user/user';
+import { Bert } from 'meteor/themeteorchef:bert';
+import { Meteor } from 'meteor/meteor';
+import AutoForm from 'uniforms-semantic/AutoForm';
+import TextField from 'uniforms-semantic/TextField';
+import LongTextField from 'uniforms-semantic/LongTextField';
+import SubmitField from 'uniforms-semantic/SubmitField';
+import HiddenField from 'uniforms-semantic/HiddenField';
+import ErrorsField from 'uniforms-semantic/ErrorsField';
+
+/** Renders the Page for editing a single document. */
+class CreateUserProfile extends React.Component {
+  constructor(props) {
+    super(props);
+    this.submit = this.submit.bind(this);
+    this.insertCallback = this.insertCallback.bind(this);
+    this.formRef = null;
+  }
+
+  insertCallback(error) {
+    if (error) {
+      Bert.alert({ type: 'danger', message: `Add failed: ${error.message}` });
+    } else {
+      Bert.alert({ type: 'success', message: 'Add succeeded' });
+      this.formRef.reset();
+    }
+  }
+
+  /** On successful submit, insert the data. */
+  submit(data) {
+    const { firstName, lastName, description, image } = data;
+    const username = Meteor.user().username;
+    Users.insert({ firstName, lastName, description, image, username }, this.insertCallback);
+  }
+
+  /** If the subscription(s) have been received, render the page, otherwise show a loading icon. */
+
+  /** Render the form. Use Uniforms: https://github.com/vazco/uniforms */
+  render() {
+    const formStyle = {
+      marginTop: '64px',
+      marginBottom: '64px',
+      paddingBottom: '16vh',
+    };
+    return (
+        <Container>
+          <style>{'body { background: url(images/uh-logo.png) no-repeat center fixed; }'}</style>
+          <style>{'body { background-color: #def2f1; }'}</style>
+          <Grid style={formStyle} container centered>
+            <Grid.Column>
+              <Header as="h2" textAlign="center">Create Your Profile</Header>
+              <AutoForm ref={(ref) => { this.formRef = ref; }} schema={UserSchema} onSubmit={this.submit}>
+                <Segment>
+                  <TextField name='firstName'/>
+                  <TextField name='lastName'/>
+                  <LongTextField name='description'/>
+                  <TextField name='image'/>
+                  <SubmitField value='Submit'/>
+                  <ErrorsField/>
+                  <HiddenField name='username' value='fakeuser@foo.com'/>
+                </Segment>
+              </AutoForm>
+            </Grid.Column>
+          </Grid>
+        </Container>
+    );
+  }
+}
+
+export default CreateUserProfile;

--- a/app/imports/ui/pages/NotifyAdmin.jsx
+++ b/app/imports/ui/pages/NotifyAdmin.jsx
@@ -1,15 +1,13 @@
 import React from 'react';
-import { Stuffs, StuffSchema } from '/imports/api/stuff/stuff';
+import { StuffSchema } from '/imports/api/stuff/stuff';
 import { Grid, Segment, Header } from 'semantic-ui-react';
 import AutoForm from 'uniforms-semantic/AutoForm';
 import TextField from 'uniforms-semantic/TextField';
 import LongTextField from 'uniforms-semantic/LongTextField';
 import SelectField from 'uniforms-semantic/SelectField';
 import SubmitField from 'uniforms-semantic/SubmitField';
-import HiddenField from 'uniforms-semantic/HiddenField';
 import ErrorsField from 'uniforms-semantic/ErrorsField';
 import { Bert } from 'meteor/themeteorchef:bert';
-import { Meteor } from 'meteor/meteor';
 
 /** Renders the Page for adding a document. */
 class NotifyAdmin extends React.Component {
@@ -33,7 +31,7 @@ class NotifyAdmin extends React.Component {
   }
 
   /** On submit, insert the data. */
-  submit(data) {
+  submit() {
     // const { name, quantity, condition } = data;
     // const owner = Meteor.user().username;
     // Stuffs.insert({ name, quantity, condition, owner }, this.insertCallback);

--- a/app/imports/ui/pages/Signup.jsx
+++ b/app/imports/ui/pages/Signup.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, Redirect } from 'react-router-dom';
 import { Container, Form, Grid, Header, Message, Segment } from 'semantic-ui-react';
 import { Accounts } from 'meteor/accounts-base';
+import PropTypes from 'prop-types';
 
 /**
  * Signup component is similar to signin component, but we attempt to create a new user instead.
@@ -10,7 +11,7 @@ export default class Signup extends React.Component {
   /** Initialize state fields. */
   constructor(props) {
     super(props);
-    this.state = { email: '', password: '', error: '' };
+    this.state = { email: '', password: '', error: '', redirectToReferer: false };
     // Ensure that 'this' is bound to this component in these two functions.
     // https://medium.freecodecamp.org/react-binding-patterns-5-approaches-for-handling-this-92c651b5af56
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -29,13 +30,18 @@ export default class Signup extends React.Component {
       if (err) {
         this.setState({ error: err.reason });
       } else {
-        // browserHistory.push('/login');
+          this.setState({ error: '', redirectToReferer: true });
       }
     });
   }
 
   /** Display the signup form. */
   render() {
+    const { from } = this.props.location.state || { from: { pathname: '/createuserprofile' } };
+    // if correct authentication, redirect to page instead of login screen
+    if (this.state.redirectToReferer) {
+      return <Redirect to={from}/>;
+    }
     return (
         <Container>
           <Grid textAlign="center" verticalAlign="middle" centered columns={2}>
@@ -83,3 +89,6 @@ export default class Signup extends React.Component {
     );
   }
 }
+Signup.propTypes = {
+  location: PropTypes.object,
+};

--- a/app/imports/ui/pages/UserProfileById.jsx
+++ b/app/imports/ui/pages/UserProfileById.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid, Loader, Header, Container, Image, Icon, Card } from 'semantic-ui-react';
+import { Grid, Loader, Header, Container, Image, Icon, Card, Rating } from 'semantic-ui-react';
 import { Users } from '/imports/api/user/user';
 import { Meteor } from 'meteor/meteor';
 import { withTracker } from 'meteor/react-meteor-data';
@@ -47,6 +47,9 @@ class UserProfileById extends React.Component {
                         10 Items for sale!
                       </a>
                     </Card.Content>
+                    <Card.Content>
+                      <Rating icon='star' defaultRating={4} maxRating={5} />
+                    </Card.Content>
                   </Card>
                 </Grid.Column>
               </Grid.Row>
@@ -67,7 +70,6 @@ class UserProfileById extends React.Component {
 /** Require the presence of a Stuff document in the props object. Uniforms adds 'model' to the props, which we use. */
 UserProfileById.propTypes = {
   doc: PropTypes.array,
-  model: PropTypes.object,
   ready: PropTypes.bool.isRequired,
 };
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2949,6 +2949,11 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
     },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    },
     "uniforms": {
       "version": "1.25.0",
       "resolved": "https://registry.npmjs.org/uniforms/-/uniforms-1.25.0.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -17,6 +17,7 @@
     "semantic-ui-css": "^2.4.0",
     "semantic-ui-react": "^0.82.5",
     "simpl-schema": "^1.5.3",
+    "underscore": "^1.9.1",
     "uniforms": "^1.25.0",
     "uniforms-semantic": "^1.25.0"
   },

--- a/config/settings.development.json
+++ b/config/settings.development.json
@@ -106,7 +106,7 @@
     {
       "title": "Rosen Text Book",
       "date": "10/28/2018",
-      "image": "rosen.jpeg",
+      "image": "images/rosen.jpeg",
       "category": "Books",
       "price": "30",
       "description": "A discrete mathematics text book for ics students, contains material for ICS 141/241",
@@ -116,7 +116,7 @@
     {
       "title": "CLRS Text Book",
       "date": "10/29/2018",
-      "image": "textbook.jpeg",
+      "image": "images/textbook.jpeg",
       "category": "Books",
       "price": "45",
       "description": "An algorithms text book for ics students, contains material for ICS 311. This book is the second most cited book in computer science. ",
@@ -126,7 +126,7 @@
     {
       "title": "Algorithms and Data Structures",
       "date": "10/03/2018",
-      "image": "dataStruct.jpeg",
+      "image": "images/dataStruct.jpeg",
       "category": "Books",
       "price": "20",
       "description": "An algorithms text book. Not sure what class this is for ",
@@ -136,16 +136,17 @@
     {
       "title": "The C Programming Language",
       "date": "10/20/2018",
-      "image": "Clan.jpeg",
+      "image": "images/Clan.jpeg",
       "category": "Books",
       "price": "45",
       "description": "The one and only complete guide to the C Programming Language",
-      "location": "Liliha"
+      "location": "Liliha",
+      "owner": "john@foo.com"
     },
     {
       "title": "89 Toyota Pickup",
       "date": "10/28/18",
-      "image": "hardbody.jpg",
+      "image": "images/hardbody.jpg",
       "category": "Vehicles",
       "price": "5000",
       "description": "Get rust, but still runs cherry",
@@ -155,7 +156,7 @@
     {
       "title": "Free Otter Pops",
       "date": "11/3/18",
-      "image": "pops.jpeg",
+      "image": "images/pops.jpeg",
       "category": "Free",
       "price": "0",
       "description": "I hate these things please take them",


### PR DESCRIPTION
**Discuss what was worked on / resolved.**
The main focus for this pull request was to update the user showcase to pull data from the items collection.  Other changes include the definition of a page for creating user profiles because there was formerly now way to add newly registered users to the database.  Upon successful registration, the user is now rerouted to the create a profile page which adds them to the Users collection. 

Unrelated changes include de-linting and other minro bug fixes.

**What other issues arose while working?**
The main outstanding related issue is that the user showcase pulls *all* the data from the collection.


