### PR TITLE
Create admin page 

### DIFF
--- a/app/imports/ui/components/CategoryAdmin.jsx
+++ b/app/imports/ui/components/CategoryAdmin.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Table, Button } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { confirmAlert } from 'react-confirm-alert'; // Import
+import 'react-confirm-alert/src/react-confirm-alert.css'; // Import css
+import { Bert } from 'meteor/themeteorchef:bert';
+import { Categories } from '/imports/api/category/category';
+
+/** Renders a single row in the List Stuff (Admin) table. See pages/ListStuffAdmin.jsx. */
+class CategoryAdmin extends React.Component {
+
+  handleClick() {
+    confirmAlert({
+      title: 'Confirm to submit',
+      message: 'Are you sure to do this.',
+      buttons: [
+        {
+          label: 'Yes',
+          onClick: () => Categories.remove(this.props.category._id, this.deleteCallback()),
+        },
+        {
+          label: 'No',
+          onClick: () => console.log('No'),
+        },
+      ],
+    });
+  }
+
+  deleteCallback(error) {
+    if (error) {
+      Bert.alert({ type: 'danger', message: `Delete failed: ${error.message}` });
+    } else {
+      Bert.alert({ type: 'success', message: 'Delete succeeded' });
+    }
+  }
+
+  render() {
+    return (
+        <Table.Row>
+          <Table.Cell>{this.props.category.name}</Table.Cell>
+          <Table.Cell>{this.props.category.icon}</Table.Cell>
+          <Table.Cell>{this.props.category._id}</Table.Cell>
+          <Table.Cell>
+            <Button><Link to={`/edit-category/${this.props.category._id}`}>Edit</Link></Button>
+            <Button color='red' basic onClick={this.handleClick}>Delete</Button>
+          </Table.Cell>
+        </Table.Row>
+    );
+  }
+}
+
+/** Require a document to be passed to this component. */
+CategoryAdmin.propTypes = {
+  category: PropTypes.object.isRequired,
+};
+
+export default CategoryAdmin;

--- a/app/imports/ui/components/ItemAdmin.jsx
+++ b/app/imports/ui/components/ItemAdmin.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Button, Table } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { confirmAlert } from 'react-confirm-alert'; // Import
+import 'react-confirm-alert/src/react-confirm-alert.css'; // Import css
+import { Bert } from 'meteor/themeteorchef:bert';
+import { Items } from '/imports/api/item/item';
+
+/** Renders a single row in the List Stuff (Admin) table. See pages/ListStuffAdmin.jsx. */
+class ItemAdmin extends React.Component {
+
+  handleClick() {
+    confirmAlert({
+      title: 'Confirm to submit',
+      message: 'Are you sure to do this.',
+      buttons: [
+        {
+          label: 'Yes',
+          onClick: () => Items.remove(this.props.item._id, this.deleteCallback()),
+        },
+        {
+          label: 'No',
+          onClick: () => console.log('No'),
+        },
+      ],
+    });
+  }
+
+  deleteCallback(error) {
+    if (error) {
+      Bert.alert({ type: 'danger', message: `Delete failed: ${error.message}` });
+    } else {
+      Bert.alert({ type: 'success', message: 'Delete succeeded' });
+    }
+  }
+
+  render() {
+    return (
+        <Table.Row>
+          <Table.Cell>{this.props.item.title}</Table.Cell>
+          <Table.Cell>{this.props.item.price}</Table.Cell>
+          <Table.Cell>{this.props.item._id}</Table.Cell>
+          <Table.Cell>{this.props.item.owner}</Table.Cell>
+          <Table.Cell>
+            <Button><Link to={`/edit-item/${this.props.item._id}`}>Edit</Link></Button>
+            <Button color='red' basic onClick={this.handleClick}>Delete</Button>
+          </Table.Cell>
+        </Table.Row>
+    );
+  }
+}
+
+/** Require a document to be passed to this component. */
+ItemAdmin.propTypes = {
+  item: PropTypes.object.isRequired,
+};
+
+export default ItemAdmin;

--- a/app/imports/ui/components/ReportAdmin.jsx
+++ b/app/imports/ui/components/ReportAdmin.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Button, Table } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { confirmAlert } from 'react-confirm-alert'; // Import
+import 'react-confirm-alert/src/react-confirm-alert.css'; // Import css
+import { Bert } from 'meteor/themeteorchef:bert';
+import { Reports } from '/imports/api/report/report';
+
+/** Renders a single row in the List Stuff (Admin) table. See pages/ListStuffAdmin.jsx. */
+class ReportAdmin extends React.Component {
+
+  handleClick() {
+    confirmAlert({
+      title: 'Confirm to submit',
+      message: 'Are you sure to do this.',
+      buttons: [
+        {
+          label: 'Yes',
+          onClick: () => Reports.remove(this.props.report._id, this.deleteCallback()),
+        },
+        {
+          label: 'No',
+          onClick: () => console.log('No'),
+        },
+      ],
+    });
+  }
+
+  deleteCallback(error) {
+    if (error) {
+      Bert.alert({ type: 'danger', message: `Delete failed: ${error.message}` });
+    } else {
+      Bert.alert({ type: 'success', message: 'Delete succeeded' });
+    }
+  }
+
+  render() {
+    return (
+        <Table.Row>
+          <Table.Cell>{this.props.report.name}</Table.Cell>
+          <Table.Cell>{this.props.report.issue}</Table.Cell>
+          <Table.Cell>{this.props.report._id}</Table.Cell>
+          <Table.Cell>{this.props.report.owner}</Table.Cell>
+          <Table.Cell>
+            <Button><Link to={`/edit-report/${this.props.report._id}`}>Edit</Link></Button>
+            <Button color='red' basic onClick={this.handleClick}>Delete</Button>
+          </Table.Cell>
+        </Table.Row>
+    );
+  }
+}
+
+/** Require a document to be passed to this component. */
+ReportAdmin.propTypes = {
+  report: PropTypes.object.isRequired,
+};
+
+export default ReportAdmin;

--- a/app/imports/ui/components/UserAdmin.jsx
+++ b/app/imports/ui/components/UserAdmin.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Button, Table } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { confirmAlert } from 'react-confirm-alert'; // Import
+import 'react-confirm-alert/src/react-confirm-alert.css'; // Import css
+import { Bert } from 'meteor/themeteorchef:bert';
+import { Users } from '/imports/api/user/user';
+
+/** Renders a single row in the List Stuff (Admin) table. See pages/ListStuffAdmin.jsx. */
+class UserAdmin extends React.Component {
+
+  handleClick() {
+    confirmAlert({
+      title: 'Confirm to submit',
+      message: 'Are you sure to do this.',
+      buttons: [
+        {
+          label: 'Yes',
+          onClick: () => Users.remove(this.props.user._id, this.deleteCallback()),
+        },
+        {
+          label: 'No',
+          onClick: () => console.log('No'),
+        },
+      ],
+    });
+  }
+
+  deleteCallback(error) {
+    if (error) {
+      Bert.alert({ type: 'danger', message: `Delete failed: ${error.message}` });
+    } else {
+      Bert.alert({ type: 'success', message: 'Delete succeeded' });
+    }
+  }
+
+  render() {
+    return (
+        <Table.Row>
+          <Table.Cell>{this.props.user.firstName} {this.props.user.lastName}</Table.Cell>
+          <Table.Cell>{this.props.user.username}</Table.Cell>
+          <Table.Cell>{this.props.user._id}</Table.Cell>
+          <Table.Cell>{this.props.user.image}</Table.Cell>
+          <Table.Cell>{this.props.user.description}</Table.Cell>
+          <Table.Cell>
+            <Button><Link to={`/edit-user/${this.props.user._id}`}>Edit</Link></Button>
+            <Button color='red' basic onClick={this.handleClick}>Delete</Button>
+          </Table.Cell>
+        </Table.Row>
+    );
+  }
+}
+
+/** Require a document to be passed to this component. */
+UserAdmin.propTypes = {
+  user: PropTypes.object.isRequired,
+};
+
+export default UserAdmin;

--- a/app/imports/ui/layouts/App.jsx
+++ b/app/imports/ui/layouts/App.jsx
@@ -7,7 +7,7 @@ import { HashRouter as Router, Route, Switch, Redirect } from 'react-router-dom'
 import NavBar from '../components/NavBar';
 import Footer from '../components/Footer';
 import UHBazaar from '../pages/UHBazaar';
-import ListStuffAdmin from '../pages/ListStuffAdmin';
+import AdminPage from '../pages/AdminPage';
 import AddStuff from '../pages/NotifyAdmin';
 import CreateItem from '../pages/CreateItem';
 import EditStuff from '../pages/EditStuff';
@@ -23,6 +23,10 @@ import ShowUsers from '../pages/ShowUsers';
 import UserProfileById from '../pages/UserProfileById';
 import CreateUserProfile from '../pages/CreateUserProfile';
 import ShowItem from '../components/ShowItem';
+import EditUserAdmin from '../pages/EditUserAdmin';
+import EditCategoryAdmin from '../pages/EditCategoryAdmin';
+import EditItemAdmin from '../pages/EditItemAdmin';
+import EditReportAdmin from '../pages/EditReportAdmin';
 
 /** Top-level layout component for this application. Called in imports/startup/client/startup.jsx. */
 class App extends React.Component {
@@ -46,7 +50,11 @@ class App extends React.Component {
               <ProtectedRoute path="/edit/:_id" component={EditStuff}/>
               <ProtectedRoute path="/edituserprofile/:_id" component={EditUserProfile}/>
               <ProtectedRoute path="/userprofilebyid/:_id" component={UserProfileById}/>
-              <AdminProtectedRoute path="/admin" component={ListStuffAdmin}/>
+              <AdminProtectedRoute path="/admin" component={AdminPage}/>
+              <AdminProtectedRoute path="/edit-user" component={EditUserAdmin}/>
+              <AdminProtectedRoute path="/edit-category" component={EditCategoryAdmin}/>
+              <AdminProtectedRoute path="/edit-item" component={EditItemAdmin}/>
+              <AdminProtectedRoute path="/edit-report" component={EditReportAdmin}/>
               <ProtectedRoute path="/signout" component={Signout}/>
               <Route component={NotFound}/>
             </Switch>

--- a/app/imports/ui/pages/AdminPage.jsx
+++ b/app/imports/ui/pages/AdminPage.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { Meteor } from 'meteor/meteor';
+import { Container, Table, Header, Loader } from 'semantic-ui-react';
+import { Items } from '/imports/api/item/item';
+import { Users } from '/imports/api/user/user';
+import { Categories } from '/imports/api/category/category';
+import { Reports } from '/imports/api/report/report';
+import ItemAdmin from '/imports/ui/components/ItemAdmin';
+import ReportAdmin from '/imports/ui/components/ReportAdmin';
+import UserAdmin from '/imports/ui/components/UserAdmin';
+import CategoryAdmin from '/imports/ui/components/CategoryAdmin';
+import { withTracker } from 'meteor/react-meteor-data';
+import PropTypes from 'prop-types';
+
+/** Renders a table containing all of the Stuff documents. Use <StuffItem> to render each row. */
+class ListStuffAdmin extends React.Component {
+
+  /** If the subscription(s) have been received, render the page, otherwise show a loading icon. */
+  render() {
+    return (this.props.ready) ? this.renderPage() : <Loader active>Getting data</Loader>;
+  }
+
+  /** Render the page once subscriptions have been received. */
+  renderPage() {
+    return (
+        <Container>
+          <Header as="h2" textAlign="center">Admin Page</Header>
+          <Header as="h3" textAlign="left">Reports</Header>
+          <Table celled>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>Report</Table.HeaderCell>
+                <Table.HeaderCell>Issue</Table.HeaderCell>
+                <Table.HeaderCell>ID</Table.HeaderCell>
+                <Table.HeaderCell>Progress</Table.HeaderCell>
+                <Table.HeaderCell>Edit/Delete</Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {this.props.reports.map((report) => <ReportAdmin key={report._id} report={report} />)}
+            </Table.Body>
+          </Table>
+          <Header as="h3" textAlign="left">Items For Sale</Header>
+          <Table celled>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>Item</Table.HeaderCell>
+                <Table.HeaderCell>Price</Table.HeaderCell>
+                <Table.HeaderCell>ID</Table.HeaderCell>
+                <Table.HeaderCell>Owner</Table.HeaderCell>
+                <Table.HeaderCell>Edit/Delete</Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {this.props.items.map((item) => <ItemAdmin key={item._id} item={item} />)}
+            </Table.Body>
+          </Table>
+          <Header as="h3" textAlign="left">Categories</Header>
+          <Table celled>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>Category</Table.HeaderCell>
+                <Table.HeaderCell>Icon</Table.HeaderCell>
+                <Table.HeaderCell>ID</Table.HeaderCell>
+                <Table.HeaderCell>Edit/Delete</Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {this.props.categories.map((category) => <CategoryAdmin key={category._id} category={category} />)}
+            </Table.Body>
+          </Table>
+          <Header as="h3" textAlign="left">Users</Header>
+          <Table celled>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>Name</Table.HeaderCell>
+                <Table.HeaderCell>Username</Table.HeaderCell>
+                <Table.HeaderCell>ID</Table.HeaderCell>
+                <Table.HeaderCell>Image</Table.HeaderCell>
+                <Table.HeaderCell>Description</Table.HeaderCell>
+                <Table.HeaderCell>Edit/Delete</Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {this.props.users.map((user) => <UserAdmin key={user._id} user={user} />)}
+            </Table.Body>
+          </Table>
+        </Container>
+    );
+  }
+}
+
+/** Require an array of Stuff documents in the props. */
+ListStuffAdmin.propTypes = {
+  items: PropTypes.array.isRequired,
+  reports: PropTypes.array.isRequired,
+  categories: PropTypes.array.isRequired,
+  users: PropTypes.array.isRequired,
+  ready: PropTypes.bool.isRequired,
+};
+
+/** withTracker connects Meteor data to React components. https://guide.meteor.com/react.html#using-withTracker */
+export default withTracker(() => {
+  // Get access to Stuff documents.
+  const subscription = Meteor.subscribe('Items');
+  const subscription2 = Meteor.subscribe('Reports');
+  const subscription3 = Meteor.subscribe('Categories');
+  const subscription4 = Meteor.subscribe('Users');
+  return {
+    items: Items.find({}).fetch(),
+    reports: Reports.find({}).fetch(),
+    categories: Categories.find({}).fetch(),
+    users: Users.find({}).fetch(),
+    ready: (subscription.ready() && subscription2.ready() && subscription3.ready() && subscription4.ready()),
+  };
+})(ListStuffAdmin);

--- a/app/imports/ui/pages/EditCategoryAdmin.jsx
+++ b/app/imports/ui/pages/EditCategoryAdmin.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Grid, Loader, Header, Segment } from 'semantic-ui-react';
+import { Categories, CategorySchema } from '/imports/api/category/category';
+import { Bert } from 'meteor/themeteorchef:bert';
+import AutoForm from 'uniforms-semantic/AutoForm';
+import TextField from 'uniforms-semantic/TextField';
+import SubmitField from 'uniforms-semantic/SubmitField';
+import ErrorsField from 'uniforms-semantic/ErrorsField';
+import { Meteor } from 'meteor/meteor';
+import { withTracker } from 'meteor/react-meteor-data';
+import PropTypes from 'prop-types';
+
+/** Renders the Page for editing a single document. */
+class EditCategoryAdmin extends React.Component {
+
+  /** On successful submit, insert the data. */
+  submit(data) {
+    const { name, icon, _id } = data;
+    Categories.update(_id, { $set: { name, icon } }, (error) => (error ?
+        Bert.alert({ type: 'danger', message: `Update failed: ${error.message}` }) :
+        Bert.alert({ type: 'success', message: 'Update succeeded' })));
+  }
+
+  /** If the subscription(s) have been received, render the page, otherwise show a loading icon. */
+  render() {
+    return (this.props.ready) ? this.renderPage() : <Loader active>Getting data</Loader>;
+  }
+
+  /** Render the form. Use Uniforms: https://github.com/vazco/uniforms */
+  renderPage() {
+    return (
+        <Grid container centered>
+          <Grid.Column>
+            <Header as="h2" textAlign="center" inverted>Edit Contact</Header>
+            <AutoForm schema={CategorySchema} onSubmit={this.submit} model={this.props.doc}>
+              <Segment>
+                <TextField name='name'/>
+                <TextField name='icon'/>
+                <SubmitField value='Submit'/>
+                <ErrorsField/>
+              </Segment>
+            </AutoForm>
+          </Grid.Column>
+        </Grid>
+    );
+  }
+}
+
+/** Require the presence of a Stuff document in the props object. Uniforms adds 'model' to the props, which we use. */
+EditCategoryAdmin.propTypes = {
+  doc: PropTypes.object,
+  model: PropTypes.object,
+  ready: PropTypes.bool.isRequired,
+};
+
+/** withTracker connects Meteor data to React components. https://guide.meteor.com/react.html#using-withTracker */
+export default withTracker(({ match }) => {
+  // Get the documentID from the URL field. See imports/ui/layouts/App.jsx for the route containing :_id.
+  const documentId = match.params._id;
+  // Get access to Stuff documents.
+  const subscription = Meteor.subscribe('Categories');
+  return {
+    doc: Categories.findOne(documentId),
+    ready: subscription.ready(),
+  };
+})(EditCategoryAdmin);

--- a/app/imports/ui/pages/EditItemAdmin.jsx
+++ b/app/imports/ui/pages/EditItemAdmin.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Grid, Loader, Header, Segment } from 'semantic-ui-react';
+import { Items, ItemSchema } from '/imports/api/item/item';
+import { Bert } from 'meteor/themeteorchef:bert';
+import AutoForm from 'uniforms-semantic/AutoForm';
+import TextField from 'uniforms-semantic/TextField';
+import SubmitField from 'uniforms-semantic/SubmitField';
+import ErrorsField from 'uniforms-semantic/ErrorsField';
+import { Meteor } from 'meteor/meteor';
+import { withTracker } from 'meteor/react-meteor-data';
+import PropTypes from 'prop-types';
+
+/** Renders the Page for editing a single document. */
+class EditItemAdmin extends React.Component {
+
+  /** On successful submit, insert the data. */
+  submit(data) {
+    const { name, icon, _id } = data;
+    Items.update(_id, { $set: { name, icon } }, (error) => (error ?
+        Bert.alert({ type: 'danger', message: `Update failed: ${error.message}` }) :
+        Bert.alert({ type: 'success', message: 'Update succeeded' })));
+  }
+
+  /** If the subscription(s) have been received, render the page, otherwise show a loading icon. */
+  render() {
+    return (this.props.ready) ? this.renderPage() : <Loader active>Getting data</Loader>;
+  }
+
+  /** Render the form. Use Uniforms: https://github.com/vazco/uniforms */
+  renderPage() {
+    return (
+        <Grid container centered>
+          <Grid.Column>
+            <Header as="h2" textAlign="center" inverted>Edit Contact</Header>
+            <AutoForm schema={ItemSchema} onSubmit={this.submit} model={this.props.doc}>
+              <Segment>
+                <TextField name='name'/>
+                <TextField name='icon'/>
+                <SubmitField value='Submit'/>
+                <ErrorsField/>
+              </Segment>
+            </AutoForm>
+          </Grid.Column>
+        </Grid>
+    );
+  }
+}
+
+/** Require the presence of a Stuff document in the props object. Uniforms adds 'model' to the props, which we use. */
+EditItemAdmin.propTypes = {
+  doc: PropTypes.object,
+  model: PropTypes.object,
+  ready: PropTypes.bool.isRequired,
+};
+
+/** withTracker connects Meteor data to React components. https://guide.meteor.com/react.html#using-withTracker */
+export default withTracker(({ match }) => {
+  // Get the documentID from the URL field. See imports/ui/layouts/App.jsx for the route containing :_id.
+  const documentId = match.params._id;
+  // Get access to Stuff documents.
+  const subscription = Meteor.subscribe('Items');
+  return {
+    doc: Items.findOne(documentId),
+    ready: subscription.ready(),
+  };
+})(EditItemAdmin);

--- a/app/imports/ui/pages/EditReportAdmin.jsx
+++ b/app/imports/ui/pages/EditReportAdmin.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Grid, Loader, Header, Segment } from 'semantic-ui-react';
+import { Categories, CategorySchema } from '/imports/api/report/report';
+import { Bert } from 'meteor/themeteorchef:bert';
+import AutoForm from 'uniforms-semantic/AutoForm';
+import TextField from 'uniforms-semantic/TextField';
+import SubmitField from 'uniforms-semantic/SubmitField';
+import ErrorsField from 'uniforms-semantic/ErrorsField';
+import { Meteor } from 'meteor/meteor';
+import { withTracker } from 'meteor/react-meteor-data';
+import PropTypes from 'prop-types';
+
+/** Renders the Page for editing a single document. */
+class EditCategoryAdmin extends React.Component {
+
+  /** On successful submit, insert the data. */
+  submit(data) {
+    const { name, icon, _id } = data;
+    Categories.update(_id, { $set: { name, icon } }, (error) => (error ?
+        Bert.alert({ type: 'danger', message: `Update failed: ${error.message}` }) :
+        Bert.alert({ type: 'success', message: 'Update succeeded' })));
+  }
+
+  /** If the subscription(s) have been received, render the page, otherwise show a loading icon. */
+  render() {
+    return (this.props.ready) ? this.renderPage() : <Loader active>Getting data</Loader>;
+  }
+
+  /** Render the form. Use Uniforms: https://github.com/vazco/uniforms */
+  renderPage() {
+    return (
+        <Grid container centered>
+          <Grid.Column>
+            <Header as="h2" textAlign="center" inverted>Edit Contact</Header>
+            <AutoForm schema={CategorySchema} onSubmit={this.submit} model={this.props.doc}>
+              <Segment>
+                <TextField name='name'/>
+                <TextField name='icon'/>
+                <SubmitField value='Submit'/>
+                <ErrorsField/>
+              </Segment>
+            </AutoForm>
+          </Grid.Column>
+        </Grid>
+    );
+  }
+}
+
+/** Require the presence of a Stuff document in the props object. Uniforms adds 'model' to the props, which we use. */
+EditCategoryAdmin.propTypes = {
+  doc: PropTypes.object,
+  model: PropTypes.object,
+  ready: PropTypes.bool.isRequired,
+};
+
+/** withTracker connects Meteor data to React components. https://guide.meteor.com/react.html#using-withTracker */
+export default withTracker(({ match }) => {
+  // Get the documentID from the URL field. See imports/ui/layouts/App.jsx for the route containing :_id.
+  const documentId = match.params._id;
+  // Get access to Stuff documents.
+  const subscription = Meteor.subscribe('Categories');
+  return {
+    doc: Categories.findOne(documentId),
+    ready: subscription.ready(),
+  };
+})(EditCategoryAdmin);

--- a/app/imports/ui/pages/EditUserAdmin.jsx
+++ b/app/imports/ui/pages/EditUserAdmin.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Grid, Loader, Header, Segment } from 'semantic-ui-react';
+import { Categories, CategorySchema } from '/imports/api/user/user';
+import { Bert } from 'meteor/themeteorchef:bert';
+import AutoForm from 'uniforms-semantic/AutoForm';
+import TextField from 'uniforms-semantic/TextField';
+import SubmitField from 'uniforms-semantic/SubmitField';
+import ErrorsField from 'uniforms-semantic/ErrorsField';
+import { Meteor } from 'meteor/meteor';
+import { withTracker } from 'meteor/react-meteor-data';
+import PropTypes from 'prop-types';
+
+/** Renders the Page for editing a single document. */
+class EditCategoryAdmin extends React.Component {
+
+  /** On successful submit, insert the data. */
+  submit(data) {
+    const { name, icon, _id } = data;
+    Categories.update(_id, { $set: { name, icon } }, (error) => (error ?
+        Bert.alert({ type: 'danger', message: `Update failed: ${error.message}` }) :
+        Bert.alert({ type: 'success', message: 'Update succeeded' })));
+  }
+
+  /** If the subscription(s) have been received, render the page, otherwise show a loading icon. */
+  render() {
+    return (this.props.ready) ? this.renderPage() : <Loader active>Getting data</Loader>;
+  }
+
+  /** Render the form. Use Uniforms: https://github.com/vazco/uniforms */
+  renderPage() {
+    return (
+        <Grid container centered>
+          <Grid.Column>
+            <Header as="h2" textAlign="center" inverted>Edit Contact</Header>
+            <AutoForm schema={CategorySchema} onSubmit={this.submit} model={this.props.doc}>
+              <Segment>
+                <TextField name='name'/>
+                <TextField name='icon'/>
+                <SubmitField value='Submit'/>
+                <ErrorsField/>
+              </Segment>
+            </AutoForm>
+          </Grid.Column>
+        </Grid>
+    );
+  }
+}
+
+/** Require the presence of a Stuff document in the props object. Uniforms adds 'model' to the props, which we use. */
+EditCategoryAdmin.propTypes = {
+  doc: PropTypes.object,
+  model: PropTypes.object,
+  ready: PropTypes.bool.isRequired,
+};
+
+/** withTracker connects Meteor data to React components. https://guide.meteor.com/react.html#using-withTracker */
+export default withTracker(({ match }) => {
+  // Get the documentID from the URL field. See imports/ui/layouts/App.jsx for the route containing :_id.
+  const documentId = match.params._id;
+  // Get access to Stuff documents.
+  const subscription = Meteor.subscribe('Categories');
+  return {
+    doc: Categories.findOne(documentId),
+    ready: subscription.ready(),
+  };
+})(EditCategoryAdmin);

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1493,7 +1493,7 @@
     },
     "lodash.isempty": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
       "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
     },
     "lodash.isobject": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2521,6 +2521,11 @@
         "object-assign": "^4.1.0"
       }
     },
+    "react-confirm-alert": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/react-confirm-alert/-/react-confirm-alert-2.0.6.tgz",
+      "integrity": "sha512-9JJ9DFyU8EUcMXyfRYmfMzTkqLHM7mDTcc7XAX8eokOp/wDm62AeTBMs7NasWXN7MesKHDTC55u8FemYOWvmkQ=="
+    },
     "react-dom": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -10,6 +10,7 @@
     "prop-types": "^15.6.1",
     "react": "^16.2.0",
     "react-addons-pure-render-mixin": "^15.6.2",
+    "react-confirm-alert": "^2.0.6",
     "react-dom": "^16.2.0",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,71 +2,10 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "prop-types": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
-      "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "react": {
-      "version": "16.6.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
-      "integrity": "sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.11.2"
-      }
-    },
-    "react-flip-move": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/react-flip-move/-/react-flip-move-3.0.3.tgz",
-      "integrity": "sha512-gR2jvjUgIXI7ceFWJkr8owX4vKhV0IJoXIf/Dt7gESFe5OKiSz2H6d10mKTW8fN134NDI16J4HgEgq9pKqJd5A=="
-    },
-    "react-images-upload": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/react-images-upload/-/react-images-upload-1.2.3.tgz",
-      "integrity": "sha512-+FVKACKiIe3uL0e4iPAzqZui+YKP6/aXbpe+Ui6NA08bppc36y45qqxaiCdda/mlqJ7WpJopp7GB92bC/uHHnA==",
-      "requires": {
-        "react": "^16.2.0",
-        "react-flip-move": "^3.0.1"
-      }
-    },
-    "react-search": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/react-search/-/react-search-2.0.5.tgz",
-      "integrity": "sha1-rmQwlfSQH/8Nhq+tvr9cWywxgps="
-    },
-    "scheduler": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.2.tgz",
-      "integrity": "sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
+    "react-confirm-alert": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/react-confirm-alert/-/react-confirm-alert-2.0.6.tgz",
+      "integrity": "sha512-9JJ9DFyU8EUcMXyfRYmfMzTkqLHM7mDTcc7XAX8eokOp/wDm62AeTBMs7NasWXN7MesKHDTC55u8FemYOWvmkQ=="
     }
   }
 }


### PR DESCRIPTION
This pull request creates an admin page that shows all of the collections in a table format. There are edit and delete buttons with partially but not complete functionality. 
Each collection has a page for editing the item (not working yet).
Each collection has a component for displaying all of its contents. 
The App has been edited to be able to reach all of the created pages only as an admin. 
The admin tab in the NavBar links to the new AdminPage.

The next step is to get the edit and delete functions working properly. 