### PR TITLE
Issue 79

### DIFF
--- a/app/imports/ui/components/OwnerShowcaseItem.jsx
+++ b/app/imports/ui/components/OwnerShowcaseItem.jsx
@@ -22,7 +22,9 @@ class OwnerShowcaseItem extends React.Component {
   }
 
   onClick() {
-    Items.remove(this.props.item._id, this.deleteCallback);
+    if (confirm('The item will be gone for good!')) {
+      Items.remove(this.props.item._id, this.deleteCallback);
+    }
   }
 
   render() {

--- a/app/imports/ui/components/ShowItem.jsx
+++ b/app/imports/ui/components/ShowItem.jsx
@@ -7,6 +7,7 @@ import { Items } from '../../api/item/item';
 
 /** Renders a single row in the List Stuff table. See pages/ListStuff.jsx. */
 class ShowItem extends React.Component {
+
   render() {
     const gridStyle = { marginBottom: '16vh', marginTop: '128px' };
     const button = { backgroundColor: '#3aafa9', color: '#feffff' };
@@ -27,7 +28,7 @@ class ShowItem extends React.Component {
                 </Card.Content>
                 <Card.Content textAlign='center' extra>
                   <Button.Group textAlign='center'>
-                    <Button animated='vertical' style={button} size='medium'>
+                    <Button href={`mailto:${this.props.item.owner}`} animated='vertical' style={button} size='medium'>
                       <Button.Content visible>Barter!</Button.Content>
                       <Button.Content hidden>
                         <Icon name='money bill alternate'/>

--- a/app/imports/ui/components/ShowcaseItem.jsx
+++ b/app/imports/ui/components/ShowcaseItem.jsx
@@ -27,7 +27,7 @@ class ShowcaseItem extends React.Component {
               <Item.Description style={cardFontStyle}>
                 {this.props.item.description}
               </Item.Description>
-              <Button animated='vertical' style={button} size='large'>
+              <Button href={`mailto:${this.props.item.owner}`} animated='vertical' style={button} size='large'>
                 <Button.Content visible>Barter!</Button.Content>
                 <Button.Content hidden>
                   <Icon name='money bill alternate'/>

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1493,7 +1493,7 @@
     },
     "lodash.isempty": {
       "version": "4.4.0",
-      "resolved": "http://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
       "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
     },
     "lodash.isobject": {


### PR DESCRIPTION
This pull request resolves #79 with a simple email exchange upon clicking the barter button.

Exchange could be expanded to text alerts, and posts on items.

The email feature was simply handled by...
```
<Button href={`mailto:${this.props.item.owner}`} animated='vertical' style={button} size='medium'>
```